### PR TITLE
Use splat syntax for outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -15,9 +15,9 @@ output "interface_vpce_sg_id" {
 }
 
 output "ssm_iam_role_name" {
-  value = "${aws_iam_role.ssm.name}"
+  value = "${aws_iam_role.ssm.*.name}"
 }
 
 output "ssm_instance_profile_name" {
-  value = "${aws_iam_instance_profile.ssm.name}"
+  value = "${aws_iam_instance_profile.ssm.*.name}"
 }


### PR DESCRIPTION
The SSM resources use `count` to make them optional, which therefore requires
splat syntax to be used for their related outputs.