### PR TITLE
Output the base domain name of the DKR endpoint

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -41,3 +41,7 @@ output "ssm_iam_role_name" {
 output "ssm_instance_profile_name" {
   value = "${element(concat(aws_iam_instance_profile.ssm.*.name, list("")), 0)}"
 }
+
+output "ecr_dkr_domain_name" {
+  value = "dkr.ecr.${var.region}.amazonaws.com"
+}


### PR DESCRIPTION
This can be used by called to set up a dependency between their ECS cluster
and the DKR endpoint. If this isn't done, there's a risk that the ECS cluster
will be provisioned before the endpoint is available leading to a deployment
failure.