### PR TITLE
output the full VPC object

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "vpc" {
+  value = aws_vpc.vpc
+}
+
 output "vpc_id" {
   value = aws_vpc.vpc.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,18 +2,6 @@ output "vpc" {
   value = aws_vpc.vpc
 }
 
-output "vpc_id" {
-  value = aws_vpc.vpc.id
-}
-
-output "vpc_cidr_block" {
-  value = aws_vpc.vpc.cidr_block
-}
-
-output "main_route_table_id" {
-  value = aws_vpc.vpc.main_route_table_id
-}
-
 output "interface_vpce_sg_id" {
   value = aws_security_group.vpc_endpoints.id
 }


### PR DESCRIPTION
Note: we can now deprecate the `aws_vpc.vpc.*` outputs

Signed-off-by: Daniel Hill <danhill@digital.uc.dwp.gov.uk>