### PR TITLE
Fix SG rule creation on new VPC

### DIFF
--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -60,27 +60,25 @@ resource "aws_security_group" "vpc_endpoints" {
 }
 
 resource "aws_security_group_rule" "vpce_source_https_ingress" {
-  for_each = var.interface_vpce_source_security_group_ids
-
+  count                    = length(var.interface_vpce_source_security_group_ids)
   description              = "Accept VPCE traffic"
   type                     = "ingress"
   protocol                 = "tcp"
   from_port                = 443
   to_port                  = 443
-  source_security_group_id = each.value
+  source_security_group_id = var.interface_vpce_source_security_group_ids[count.index]
   security_group_id        = aws_security_group.vpc_endpoints.id
 }
 
 resource "aws_security_group_rule" "source_vpce_https_egress" {
-  for_each = var.interface_vpce_source_security_group_ids
-
+  count                    = length(var.interface_vpce_source_security_group_ids)
   description              = "Allow outbound requests to VPC endpoints"
   type                     = "egress"
   protocol                 = "tcp"
   from_port                = 443
   to_port                  = 443
   source_security_group_id = aws_security_group.vpc_endpoints.id
-  security_group_id        = each.value
+  security_group_id        = var.interface_vpce_source_security_group_ids[count.index]
 }
 
 resource "aws_security_group" "custom_vpc_endpoints" {


### PR DESCRIPTION
When attempting to create SG rules for SGs that haven't yet been created,
i.e. `interface_vpce_source_security_group_ids = [aws_security_group.my_sg.id]`
and `my_sg` isn't present, Terraform complains like this:

```
Error: Invalid for_each argument
  on .terraform/modules/vpc/terraform-aws-vpc-3.0.1/vpc_endpoints.tf line 63, in resource "aws_security_group_rule" "vpce_source_https_ingress":
  63:   for_each = var.interface_vpce_source_security_group_ids
The "for_each" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the for_each depends on.
```

Fix that by simply using a count; there's no need for the complex loop logic
that `for_each` provides.