### PR TITLE
Create VPC Endpoint Subnet Associations instead of inline attachments

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,5 +17,25 @@ locals {
   service_names_with_dns      = setunion(local.interface_endpoints_to_create, var.custom_vpce_services[*].key)
   endpoint_resources_with_dns = merge(aws_vpc_endpoint.custom_vpc_endpoints, aws_vpc_endpoint.aws_interface_vpc_endpoints)
 
+  if_vpces = [
+    for key, endpoint in aws_vpc_endpoint.aws_interface_vpc_endpoints : {
+      key = endpoint.service_name
+      id  = endpoint.id
+    }
+  ]
 
+  if_vpce_subnets = [
+    for key, subnet in var.interface_vpce_subnet_ids : {
+      key = key
+      id  = subnet
+    }
+  ]
+
+  if_vpce_subnet_assocs = [
+    for pair in setproduct(local.if_vpces, local.if_vpce_subnets) : {
+      service_name = pair[0].key
+      endpoint_id  = pair[0].id
+      subnet_id    = pair[1].id
+    }
+  ]
 }

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -5,13 +5,20 @@ resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
   vpc_id              = aws_vpc.vpc.id
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  subnet_ids          = var.interface_vpce_subnet_ids
   private_dns_enabled = true
 
   tags = merge(
     var.common_tags,
     { Name = var.vpc_name }
   )
+}
+
+resource "aws_vpc_endpoint_subnet_association" "aws_vpce_subnet_assoc" {
+  for_each = {
+    for assoc in local.if_vpce_subnet_assocs : "${assoc.service_name}.${assoc.subnet_id}" => assoc
+  }
+  vpc_endpoint_id = each.value.endpoint_id
+  subnet_id       = each.value.subnet_id
 }
 
 resource "aws_vpc_endpoint" "aws_gateway_vpc_endpoints" {


### PR DESCRIPTION
When trying to change subnet ranges that have VPC Endpoints attached,
Terraform tries to delete the subnet before recreating it but the API
prevents it from doing that because of those VPC Endpoint ENIs
(https://github.com/terraform-providers/terraform-provider-aws/issues/8536).

Using explicit vpc_endpoint_subnet_association resources ensures the
correct ordering of API calls to avoid that issue.