### PR TITLE
VPC Endpoint Subnet Associations

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,5 +17,13 @@ locals {
   service_names_with_dns      = setunion(local.interface_endpoints_to_create, var.custom_vpce_services[*].key)
   endpoint_resources_with_dns = merge(aws_vpc_endpoint.custom_vpc_endpoints, aws_vpc_endpoint.aws_interface_vpc_endpoints)
 
+  vpce_id_subnet_id_combinations = [
+    # in pair, element zero is a VPCE ID and element one is a Subnet ID,
+    # in all unique combinations.
+    for pair in setproduct(aws_vpc_endpoint.aws_interface_vpc_endpoints.*.id, var.interface_vpce_subnet_ids) : {
+      vpce_id   = pair[0]
+      subnet_id = pair[1]
+    }
+  ]
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,11 +1,10 @@
 locals {
   gateway_services = ["dynamodb", "s3"]
 
-  # This essentially implements the 'setsubtract' function available in Terraform v.0.12.21 and later
-  interface_endpoints_to_create = toset([
+  interface_endpoints_to_create = [
     for service in var.aws_vpce_services :
     service if ! contains(local.gateway_services, service)
-  ])
+  ]
 
   gateway_endpoints_to_create = setintersection(var.aws_vpce_services, local.gateway_services)
 
@@ -17,7 +16,7 @@ locals {
   service_names_with_dns      = setunion(local.interface_endpoints_to_create, var.custom_vpce_services[*].key)
   endpoint_resources_with_dns = merge(aws_vpc_endpoint.custom_vpc_endpoints, aws_vpc_endpoint.aws_interface_vpc_endpoints)
 
-  vpce_id_subnet_id_combinations = [
+  vpce_subnet_combinations = [
     # in pair, element zero is a VPCE ID and element one is a Subnet ID,
     # in all unique combinations.
     for pair in setproduct(aws_vpc_endpoint.aws_interface_vpc_endpoints.*.id, var.interface_vpce_subnet_ids) : {

--- a/variables.tf
+++ b/variables.tf
@@ -41,8 +41,8 @@ variable "vpc_flow_log_traffic_type" {
 }
 
 variable "aws_vpce_services" {
-  type        = set(string)
-  description = "Set of AWS Service names to create VPC Endpoints for. By default only the 'logs' service endpoint is provided"
+  type        = list(string)
+  description = "A list of AWS Service names to create VPC Endpoints for. By default only the 'logs' service endpoint is provided"
   default     = ["logs"]
 }
 

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -5,7 +5,6 @@ resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
   vpc_id              = aws_vpc.vpc.id
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  subnet_ids          = var.interface_vpce_subnet_ids
   private_dns_enabled = true
 
   tags = merge(
@@ -13,6 +12,14 @@ resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
     { Name = var.vpc_name }
   )
 }
+
+resource "aws_vpc_endpoint_subnet_association" "aws_interface_vpc_endpoints_association" {
+  count = local.vpce_id_subnet_id_combinations
+
+  vpc_endpoint_id = local.vpce_id_subnet_id_combinations[count.index].vpce_id
+  subnet_id       = local.vpce_id_subnet_id_combinations[count.index].subnet_id
+}
+
 
 resource "aws_vpc_endpoint" "aws_gateway_vpc_endpoints" {
   for_each = local.gateway_endpoints_to_create

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -1,7 +1,7 @@
 resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
-  for_each = local.interface_endpoints_to_create
+  count = length(local.interface_endpoints_to_create)
 
-  service_name        = "com.amazonaws.${var.region}.${each.value}"
+  service_name        = "com.amazonaws.${var.region}.${local.interface_endpoints_to_create[count.index]}"
   vpc_id              = aws_vpc.vpc.id
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
@@ -14,10 +14,9 @@ resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
 }
 
 resource "aws_vpc_endpoint_subnet_association" "aws_interface_vpc_endpoints_association" {
-  count = local.vpce_id_subnet_id_combinations
-
-  vpc_endpoint_id = local.vpce_id_subnet_id_combinations[count.index].vpce_id
-  subnet_id       = local.vpce_id_subnet_id_combinations[count.index].subnet_id
+  count           = length(local.vpce_subnet_combinations)
+  vpc_endpoint_id = local.vpce_subnet_combinations[count.index].vpce_id
+  subnet_id       = local.vpce_subnet_combinations[count.index].subnet_id
 }
 
 


### PR DESCRIPTION
Create VPC Endpoint Subnet Associations instead of using inline subnet_ids for Interface VPC Endpoints.

If you try to move VPC endpoints to a different set of subnets at the same time as you try to delete the old subnets will fail because TF gets the ordering wrong. It thinks it can destroy the old subnets first, because the move is just a change of attribute on the VPC  Endpoint resource. But, obviously, the VPC Endpoints are still attached to the old subnets so AWS will prevent those from being deleted.

VPC endpoint subnet associations fix this; as it's an explicit resource, TF's dependency solver will get the ordering correct.