### PR TITLE
Add secondary EMR FQDN to no_proxy list

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -32,10 +32,11 @@ locals {
   s3_no_proxy = contains(var.aws_vpce_services, "s3") ? [".s3.${var.region}.amazonaws.com"] : []
   ecr_api_no_proxy = contains(var.aws_vpce_services, "ecr.api") ? ["api.ecr.${var.region}.amazonaws.com"] : []
   ecr_dkr_no_proxy = contains(var.aws_vpce_services, "ecr.dkr") ? [".dkr.ecr.${var.region}.amazonaws.com"] : []
+  emr_no_proxy = contains(var.aws_vpce_services, "elasticmapreduce") ? ["${var.region}.elasticmapreduce.amazonaws.com"] : []
 }
 
 output "no_proxy_list" {
-  value = concat(["169.254.169.254"], formatlist("%s.%s.amazonaws.com", var.aws_vpce_services, var.region), local.s3_no_proxy, local.ecr_api_no_proxy, local.ecr_dkr_no_proxy)
+  value = concat(["169.254.169.254"], formatlist("%s.%s.amazonaws.com", var.aws_vpce_services, var.region), local.s3_no_proxy, local.ecr_api_no_proxy, local.ecr_dkr_no_proxy, local.emr_no_proxy)
 }
 
 


### PR DESCRIPTION
It turns out that some API callers hit EMR via region.elasticmapreduce.amazonaws.com
and that is a valid alias for elasticmapreduce.region.amazonaws.com. So, add that
alias to the no_proxy output so the endpoint is used for that traffic too.