### PR TITLE
allow writing of logs for provider version 3+

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "vpc_flow_logs" {
   statement {
     sid       = "VpcFlowLogs${replace(var.vpc_name, "-", "")}"
     effect    = "Allow"
-    resources = [aws_cloudwatch_log_group.vpc_flow_logs.arn]
+    resources = [format("%s:*", aws_cloudwatch_log_group.vpc_flow_logs.arn)]
 
     actions = [
       "logs:CreateLogGroup",


### PR DESCRIPTION
Since upgrading AWS Provider version to 3.22 we can no longer write logs as the resources list no longer had :* at the end. This will force this back in this release 