### PR TITLE
Switch S3 to Interface Endpoint

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  gateway_services = ["dynamodb", "s3"]
+  gateway_services = ["dynamodb"]
 
   # This essentially implements the 'setsubtract' function available in Terraform v.0.12.21 and later
   interface_endpoints_to_create = toset([

--- a/vpc_endpoints.tf
+++ b/vpc_endpoints.tf
@@ -6,7 +6,7 @@ resource "aws_vpc_endpoint" "aws_interface_vpc_endpoints" {
   vpc_endpoint_type   = "Interface"
   security_group_ids  = [aws_security_group.vpc_endpoints.id]
   subnet_ids          = var.interface_vpce_subnet_ids
-  private_dns_enabled = true
+  private_dns_enabled = each.value == "s3" ? false : true
 
   tags = merge(
     var.common_tags,


### PR DESCRIPTION
S3 PrivateLink is now GA, this PR is to remove S3 from the gateway_service list so that an interface endpoint is used instead.

https://aws.amazon.com/blogs/aws/aws-privatelink-for-amazon-s3-now-available/